### PR TITLE
GH-28: Make `name` property in License Object optional

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -36,6 +36,7 @@ This specification is heavily influenced by the [OpenAPI specification][openapi]
 | 2025-07-15 | Patrik Svensson | Added `interactive` to root command and commands |
 | 2025-07-16 | Patrik Svensson | Added [Metadata Object](#metadata-object) |
 | 2025-07-16 | Patrik Svensson | Changed maps to arrays |
+| 2025-07-18 | Patrik Svensson | `name` property in [License Object](#license-object) is no longer required |
 
 ## Definitions
 
@@ -133,7 +134,7 @@ This is the root object of the OpenCLI Description.
 
 | Field Name | Type | Description |
 |------------|:----:|-------------|
-| name | `string` | **REQUIRED** The license name |
+| name | `string` | The license name |
 | identifier | `string` | The [SPDX](https://spdx.org/licenses/) license identifier |
 
 #### Command Object

--- a/schema.json
+++ b/schema.json
@@ -347,10 +347,7 @@
                     "type": "string",
                     "description": "The SPDX license identifier"
                 }
-            },
-            "required": [
-                "name"
-            ]
+            }
         },
         "Arity": {
             "type": "object",

--- a/typespec/main.tsp
+++ b/typespec/main.tsp
@@ -76,7 +76,7 @@ model Contact {
 
 model License {
   @doc("The license name")
-  name: string;
+  name?: string;
 
   @doc("The SPDX license identifier")
   identifier?: string;


### PR DESCRIPTION
Closes #28