### PR TITLE
Add environment variables to the Open CLI specification

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -37,6 +37,7 @@ This specification is heavily influenced by the [OpenAPI specification][openapi]
 | 2025-07-16 | Patrik Svensson | Added [Metadata Object](#metadata-object) |
 | 2025-07-16 | Patrik Svensson | Changed maps to arrays |
 | 2025-07-18 | Patrik Svensson | `name` property in [License Object](#license-object) is no longer required |
+| 2025-07-28 | Chris McGee | Added environment variables |
 
 ## Definitions
 
@@ -103,6 +104,7 @@ This is the root object of the OpenCLI Description.
 | exitCodes | [[ExitCode Object](#exitcode-object)] | Root command exit codes |
 | examples | [`string`] | Examples of how to use the CLI |
 | interactive | `bool` | Indicates whether or not the command requires interactive input |
+| environmentVariables | [[EnvironmentVariable Object](#environmentvariable-object)] | Environment variables used by this command |
 | metadata | [[Metadata Object](#metadata-object)] | Custom metadata |
 
 #### CliInfo Object
@@ -178,6 +180,7 @@ This is the root object of the OpenCLI Description.
 | group | `string` | The option group |
 | description | `string` | The option description |
 | hidden | `bool` | Whether or not the option is hidden |
+| environmentVariable | [[EnvironmentVariable Object](#environmentvariable-object)] | A related environment variable that is used as the default value for the option |
 | metadata | [[Metadata Object](#metadata-object)] | Custom metadata |
 
 #### Arity Object
@@ -193,6 +196,13 @@ This is the root object of the OpenCLI Description.
 |------------|:----:|-------------|
 | code | `int` | **REQUIRED** The exit code |
 | description | `string` | The exit code description |
+
+#### EnvironmentVariable Object
+
+| Field Name | Type | Description |
+|------------|:----:|-------------|
+| name | `string` | **REQUIRED** The name of the environment variable |
+| metadata | [[Metadata Object](#metadata-object)] | Custom metadata |
 
 #### Metadata Object
 

--- a/schema.json
+++ b/schema.json
@@ -36,6 +36,13 @@
             },
             "description": "Root command sub commands"
         },
+        "environmentVariables": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/EnvironmentVariable"
+            },
+            "description": "Environment variables used by this command"
+        },
         "exitCodes": {
             "type": "array",
             "items": {
@@ -201,6 +208,10 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Whether or not the option is hidden"
+                },
+                "environmentVariable": {
+                    "$ref": "#/$defs/EnvironmentVariable",
+                    "description": "A related environment variable that is used as the default value for the option"
                 },
                 "metadata": {
                     "type": "array",
@@ -368,6 +379,23 @@
         "email": {
             "type": "string",
             "pattern": ".+\\@.+\\..+"
+        },
+        "EnvironmentVariable": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the environment variable"
+                },
+                "metadata": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Metadata"
+                    },
+                    "description": "Custom metadata"
+                }
+            },
+            "required": ["name"]
         }
     }
 }

--- a/typespec/main.tsp
+++ b/typespec/main.tsp
@@ -33,6 +33,9 @@ model OpenCLI {
   @doc("Indicates whether or not the command requires interactive input")
   interactive?: boolean;
 
+  @doc("Environment variables used by this command")
+  environmentVariables?: EnvironmentVariable[];
+
   @doc("Custom metadata")
   metadata?: Metadata[];
 }
@@ -170,6 +173,9 @@ model Option {
   @doc("Whether or not the option is hidden")
   hidden?: boolean = false;
 
+  @doc("A related environment variable that is used as the default value for the option")
+  environmentVariable?: EnvironmentVariable;
+
   @doc("Custom metadata")
   metadata?: Metadata[];
 }
@@ -196,4 +202,12 @@ model Arity {
 model Metadata {
   name: string;
   value?: unknown;
+}
+
+model EnvironmentVariable {
+  @doc("The name of the environment variable")
+  name: string;
+
+  @doc("Custom metadata")
+  metadata?: Metadata[];
 }


### PR DESCRIPTION
Environment variables can affect the way that a command-line tool works in a variety of ways, as much as options, and arguments can. Add a section to the specification where all of the environment variables used by the tool can be declared and described.

Options can sometimes take their default value from an environment variable too. Permit referring to an environment variable so that this relationship can be documented.