### PR TITLE
Fix typo in argument description field

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -169,7 +169,7 @@ This is the root object of the OpenCLI Description.
 | arity | [Arity Object](#arity-object) | - | The argument arity. Arity defines the minimum and maximum number of argument values |
 | acceptedValues | [`string`] | - | A list of accepted values |
 | group | `string` | - | The argument group |
-| decription | `string` | - | The argument description |
+| description | `string` | - | The argument description |
 | hidden | `bool` | `false` | Whether or not the argument is hidden |
 | metadata | [[Metadata Object](#metadata-object)] | - | Custom metadata |
 


### PR DESCRIPTION
Noticed a typo in the documentation. I don't think this is true of the actual spec (JSON schema) but I noticed it on the website.

Let me know if there is anything I need to do to make the PR useable. 