### PR TITLE
fix: Supply the default value for `Argument#arity` if the field is omitted

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -13,6 +13,7 @@ This document is licensed under the MIT license
 
 | Date | Author | Description |
 |------|--------|-------------|
+| 2026-03-24 | Bob Lail | Add default value for `arity` to [Argument Object](#argument-object) |
 | 2025-07-15 | Patrik Svensson | Added `interactive` to root command and commands |
 | 2025-07-16 | Patrik Svensson | Added [Metadata Object](#metadata-object) |
 | 2025-07-16 | Patrik Svensson | Changed maps to arrays |
@@ -167,7 +168,7 @@ This is the root object of the OpenCLI Description.
 |------------|:----:|---------------|-------------|
 | name | `string` | - | **REQUIRED** The argument name |
 | required | `bool` | `false` | Whether or not the argument is required |
-| arity | [Arity Object](#arity-object) | - | The argument arity. Arity defines the minimum and maximum number of argument values |
+| arity | [Arity Object](#arity-object) | `{"minimum": 1, "maximum": 1}` | The argument arity. Arity defines the minimum and maximum number of argument values |
 | acceptedValues | [`string`] | - | A list of accepted values |
 | group | `string` | - | The argument group |
 | description | `string` | - | The argument description |

--- a/schema.json
+++ b/schema.json
@@ -129,6 +129,10 @@
                 },
                 "arity": {
                     "$ref": "#/$defs/Arity",
+                    "default": {
+                        "minimum": 1,
+                        "maximum": 1
+                    },
                     "description": "The argument arity. Arity defines the minimum and maximum number of argument values"
                 },
                 "acceptedValues": {

--- a/typespec/main.tsp
+++ b/typespec/main.tsp
@@ -132,7 +132,7 @@ model Argument {
   required?: boolean = false;
 
   @doc("The argument arity. Arity defines the minimum and maximum number of argument values")
-  arity?: Arity;
+  arity?: Arity = #{ minimum: 1, maximum: 1 };
 
   @doc("A list of accepted values")
   acceptedValues?: string[];


### PR DESCRIPTION
Default values for `minimum` and `maximum` are specified by `Arity` but `Argument` doesn't specify what the default `arity` is when it is omitted.

(Pretty sure this is a fix not a change of intent — not trying to linejump Discussions!)